### PR TITLE
Use DEFAULT for blank schema

### DIFF
--- a/src/DB2Connection.php
+++ b/src/DB2Connection.php
@@ -50,7 +50,7 @@ class DB2Connection extends Connection
      */
     public function setCurrentSchema(string $schema)
     {
-        $this->statement('SET SCHEMA ?', [strtoupper($schema)]);
+        $this->statement('SET SCHEMA ?', $schema!==""?[strtoupper($schema)]:"DEFAULT");
     }
 
     /**

--- a/src/DB2Connection.php
+++ b/src/DB2Connection.php
@@ -50,7 +50,7 @@ class DB2Connection extends Connection
      */
     public function setCurrentSchema(string $schema)
     {
-        $this->statement('SET SCHEMA ?', [$schema!==""?strtoupper($schema):"DEFAULT"]);
+        $this->statement('SET SCHEMA ?', [$schema!=="" ? strtoupper($schema) : "DEFAULT"]);
     }
 
     /**

--- a/src/DB2Connection.php
+++ b/src/DB2Connection.php
@@ -50,7 +50,7 @@ class DB2Connection extends Connection
      */
     public function setCurrentSchema(string $schema)
     {
-        $this->statement('SET SCHEMA ?', $schema!==""?[strtoupper($schema)]:"DEFAULT");
+        $this->statement('SET SCHEMA ?', [$schema!==""?strtoupper($schema):"DEFAULT"]);
     }
 
     /**

--- a/src/DB2Connection.php
+++ b/src/DB2Connection.php
@@ -50,7 +50,7 @@ class DB2Connection extends Connection
      */
     public function setCurrentSchema(string $schema)
     {
-        $this->statement('SET SCHEMA ?', [$schema!=="" ? strtoupper($schema) : "DEFAULT"]);
+        $this->statement('SET SCHEMA ?', [$schema !== "" ? strtoupper($schema) : "DEFAULT"]);
     }
 
     /**


### PR DESCRIPTION
In my database connection I'm using library list (via DefaultLibraries with blank as first library) and no Schema.
When creating tables with migrations I have to specify the library as part of the create table statement (create table mylib.newTableName....). 
When migrations is run SET SCHEMA is used to set the library spesified in the create table statement, the statement is run, and in the end SET SCHEMA is set back to default schema (which is blank).
The last step fails.

Instead of setting schema to blank it should be set back to DEFAULT.