### PR TITLE
Patch for Laravel 11/12 compatibility and IBM i authority fixes

### DIFF
--- a/src/DB2Connection.php
+++ b/src/DB2Connection.php
@@ -118,10 +118,11 @@ class DB2Connection extends Connection
      * null bytes (\x00) as property-visibility markers; those bytes are
      * rejected during EBCDIC conversion (CWBNL0107 / SQLSTATE 22018).
      *
-     * Binding such strings as PDO::PARAM_LOB uses SQL_C_BINARY on the wire,
-     * which bypasses code-page conversion entirely.  The target column must be
-     * BLOB (or FOR BIT DATA) for DB2 to store the raw bytes — typeMediumText()
-     * in DB2SchemaGrammar returns 'blob' specifically to satisfy this requirement.
+     * Strings that contain null bytes are encoded as a STX byte (\x02) followed
+     * by the hex representation of the original string (bin2hex).  The resulting
+     * string contains only ASCII characters 0-9 and a-f, which survive EBCDIC
+     * conversion unchanged.  DB2Processor::processSelect() detects the \x02
+     * prefix on read and reverses the encoding via hex2bin().
      */
     public function bindValues($statement, $bindings)
     {
@@ -133,8 +134,11 @@ class DB2Connection extends Connection
             } elseif (is_int($value)) {
                 $statement->bindValue($pdoParam, $value, PDO::PARAM_INT);
             } elseif (is_string($value) && str_contains($value, "\x00")) {
-                // Null bytes present — bind as binary LOB to bypass EBCDIC conversion.
-                $statement->bindValue($pdoParam, $value, PDO::PARAM_LOB);
+                // Null bytes present (e.g. PHP serialize() protected-property markers).
+                // Encode as STX-marker + hex so the string contains only printable ASCII
+                // characters that survive EBCDIC conversion without modification.
+                // DB2Processor::processSelect() reverses this on read.
+                $statement->bindValue($pdoParam, "\x02" . bin2hex($value), PDO::PARAM_STR);
             } else {
                 $statement->bindValue($pdoParam, $value, PDO::PARAM_STR);
             }

--- a/src/DB2Connection.php
+++ b/src/DB2Connection.php
@@ -111,6 +111,22 @@ class DB2Connection extends Connection
     }
 
     /**
+     * Get a new query builder instance for the connection.
+     *
+     * Returns DB2QueryBuilder so that upsert() can inline values directly into
+     * the SQL, bypassing PDO parameter binding which DB2 for i forbids inside
+     * MERGE...USING subqueries (SQL0584 / SQL0418).
+     */
+    public function query(): DB2QueryBuilder
+    {
+        return new DB2QueryBuilder(
+            $this,
+            $this->getQueryGrammar(),
+            $this->getPostProcessor()
+        );
+    }
+
+    /**
      * Get the default post processor instance
      */
     protected function getDefaultPostProcessor(): \Illuminate\Database\Query\Processors\Processor

--- a/src/DB2Connection.php
+++ b/src/DB2Connection.php
@@ -27,6 +27,9 @@ class DB2Connection extends Connection
         ) {
         parent::__construct($pdo, $database, $tablePrefix, $config);
         $this->currentSchema = $this->defaultSchema = strtoupper($config['schema'] ?? null);
+
+        //DWMOD - we need to set the PDO case attribute to lower case to ensure that column names are returned in lower case, which is the default behavior in Laravel, and it prevents issues with column name case sensitivity when working with DB2, which returns column names in upper case by default
+        $this->pdo->setAttribute(\PDO::ATTR_CASE, \PDO::CASE_LOWER);
     }
 
     /**
@@ -78,7 +81,9 @@ class DB2Connection extends Connection
      */
     protected function getDefaultQueryGrammar()
     {
-        $defaultGrammar = new DB2QueryGrammar;
+        //DWMOD - DB2QueryGrammar constructor requires a reference to the connection, so we need to pass $this in the constructor
+        //$defaultGrammar = new DB2QueryGrammar
+        $defaultGrammar = new DB2QueryGrammar($this);
 
         // If a date format was specified in constructor
         if (array_key_exists('date_format', $this->config)) {
@@ -90,7 +95,9 @@ class DB2Connection extends Connection
             $defaultGrammar->setOffsetCompatibilityMode($this->config['offset_compatibility_mode']);
         }
 
-        return $this->withTablePrefix($defaultGrammar);
+        //DWMOD - we are not using table prefixes, and the withTablePrefix method is not implemented in the DB2QueryGrammar class, so we will just return the default grammar without applying a table prefix
+        //return $this->withTablePrefix($defaultGrammar);
+        return $defaultGrammar;
     }
 
     /**
@@ -98,7 +105,9 @@ class DB2Connection extends Connection
      */
     protected function getDefaultSchemaGrammar(): \Illuminate\Database\Grammar
     {
-        return new DB2SchemaGrammar;
+        //DWMOD DB2SchemaGrammar constructor requires a reference to the connection, so we need to pass $this in the constructor
+        //return new DB2SchemaGrammar;
+        return new DB2SchemaGrammar($this);
     }
 
     /**

--- a/src/DB2Connection.php
+++ b/src/DB2Connection.php
@@ -111,6 +111,37 @@ class DB2Connection extends Connection
     }
 
     /**
+     * Bind the values to a PDO statement.
+     *
+     * IBM i's System i Access ODBC driver converts every PDO::PARAM_STR value
+     * from the job's CCSID to the column's CCSID.  PHP's serialize() embeds
+     * null bytes (\x00) as property-visibility markers; those bytes are
+     * rejected during EBCDIC conversion (CWBNL0107 / SQLSTATE 22018).
+     *
+     * Binding such strings as PDO::PARAM_LOB uses SQL_C_BINARY on the wire,
+     * which bypasses code-page conversion entirely.  The target column must be
+     * BLOB (or FOR BIT DATA) for DB2 to store the raw bytes — typeMediumText()
+     * in DB2SchemaGrammar returns 'blob' specifically to satisfy this requirement.
+     */
+    public function bindValues($statement, $bindings)
+    {
+        foreach ($bindings as $key => $value) {
+            $pdoParam = is_string($key) ? $key : $key + 1;
+
+            if (is_resource($value)) {
+                $statement->bindValue($pdoParam, $value, PDO::PARAM_LOB);
+            } elseif (is_int($value)) {
+                $statement->bindValue($pdoParam, $value, PDO::PARAM_INT);
+            } elseif (is_string($value) && str_contains($value, "\x00")) {
+                // Null bytes present — bind as binary LOB to bypass EBCDIC conversion.
+                $statement->bindValue($pdoParam, $value, PDO::PARAM_LOB);
+            } else {
+                $statement->bindValue($pdoParam, $value, PDO::PARAM_STR);
+            }
+        }
+    }
+
+    /**
      * Get a new query builder instance for the connection.
      *
      * Returns DB2QueryBuilder so that upsert() can inline values directly into

--- a/src/DB2Processor.php
+++ b/src/DB2Processor.php
@@ -38,6 +38,39 @@ class DB2Processor extends Processor
     }
 
     /**
+     * Process the results of a "select" query.
+     *
+     * Reverses the STX + hex encoding applied by DB2Connection::bindValues() for
+     * strings that originally contained null bytes (e.g. PHP serialize() output).
+     * Any column value that starts with \x02 followed by an even-length string of
+     * valid hex characters is decoded via hex2bin().  All other values are returned
+     * unchanged.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $results
+     * @return array
+     */
+    public function processSelect(Builder $query, $results)
+    {
+        return array_map(function ($row) {
+            foreach (get_object_vars($row) as $key => $value) {
+                if (
+                    is_string($value)
+                    && isset($value[0])
+                    && $value[0] === "\x02"
+                ) {
+                    $hex = substr($value, 1);
+                    if (strlen($hex) % 2 === 0 && ctype_xdigit($hex)) {
+                        $row->$key = hex2bin($hex);
+                    }
+                }
+            }
+
+            return $row;
+        }, $results);
+    }
+
+    /**
      * Process the results of a column listing query.
      * This was present in Illuminate\Database\Query\Processor.php 9.x but later removed.
      *

--- a/src/DB2QueryBuilder.php
+++ b/src/DB2QueryBuilder.php
@@ -26,6 +26,46 @@ class DB2QueryBuilder extends Builder
      * @param  array|null  $update
      * @return int
      */
+    /**
+     * Insert new records, ignoring rows that would violate a unique constraint.
+     *
+     * DB2 has no native INSERT OR IGNORE / INSERT IGNORE syntax, and the base
+     * Grammar throws a RuntimeException for compileInsertOrIgnore().  We
+     * implement the semantics by attempting a normal INSERT per row and silently
+     * swallowing unique-constraint violations (SQLSTATE 23505 / SQL0803).
+     *
+     * @param  array  $values
+     * @return int  Number of rows actually inserted.
+     */
+    public function insertOrIgnore(array $values): int
+    {
+        if (empty($values)) {
+            return 0;
+        }
+        if (! is_array(reset($values))) {
+            $values = [$values];
+        } else {
+            foreach ($values as $key => $value) {
+                ksort($value);
+                $values[$key] = $value;
+            }
+        }
+        $this->applyBeforeQueryCallbacks();
+        $affected = 0;
+        foreach ($values as $record) {
+            try {
+                $this->newQuery()->from($this->from)->insert($record);
+                $affected++;
+            } catch (\Illuminate\Database\QueryException $e) {
+                // SQLSTATE 23505 = unique constraint violation (DB2 SQL0803)
+                // SQLSTATE 23000 = integrity constraint violation (general)
+                if (! in_array($e->getCode(), ['23505', '23000'])) {
+                    throw $e;
+                }
+            }
+        }
+        return $affected;
+    }
     public function upsert(array $values, $uniqueBy, $update = null): int
     {
         if (empty($values)) {

--- a/src/DB2QueryBuilder.php
+++ b/src/DB2QueryBuilder.php
@@ -7,13 +7,19 @@ use Illuminate\Database\Query\Builder;
 class DB2QueryBuilder extends Builder
 {
     /**
-     * Insert new records or update the existing ones using a DB2 MERGE statement.
+     * Insert new records or update the existing ones.
      *
-     * DB2 for i refuses to prepare any MERGE...USING (...) statement that contains
-     * parameter markers (?) inside the USING subquery — regardless of whether they
-     * are bare or wrapped in CAST(...) — raising SQL0584 or SQL0418 at SQLPrepare
-     * time.  The only viable workaround is to inline all values directly into the
-     * SQL string as properly-escaped literals, then execute with no bindings.
+     * DB2 for i prohibits parameter markers (?) anywhere inside the USING subquery
+     * of a MERGE statement (SQL0584 / SQL0418), and inlining values as SQL literals
+     * breaks on strings that contain null bytes (e.g. PHP-serialised objects store
+     * protected property names as \x00*\x00name), causing SQL0010.
+     *
+     * The pragmatic solution is to implement upsert as a per-row UPDATE followed by
+     * an INSERT when no row was matched.  Both statements use normal PDO parameter
+     * binding, which handles arbitrary binary data transparently.  The sequence is
+     * not atomic, but that is acceptable for the cache and session use-cases that
+     * drive this method; callers with strict atomicity requirements should use a
+     * DB2 transaction around the call.
      *
      * @param  array  $values
      * @param  array|string  $uniqueBy
@@ -39,16 +45,43 @@ class DB2QueryBuilder extends Builder
             $update = array_keys(reset($values));
         }
 
+        $update   = is_array($update) ? $update : [$update];
+        $uniqueBy = array_values((array) $uniqueBy);
+
         $this->applyBeforeQueryCallbacks();
 
-        $sql = $this->grammar->compileUpsert(
-            $this,
-            $values,
-            array_values((array) $uniqueBy),
-            is_array($update) ? $update : [$update]
-        );
+        $affected = 0;
 
-        // All values are inlined into $sql — pass no bindings to PDO.
-        return $this->connection->affectingStatement($sql, []);
+        foreach ($values as $record) {
+            // Resolve the SET columns/values for the UPDATE.
+            $updateData = [];
+            foreach ($update as $key => $col) {
+                if (is_numeric($key)) {
+                    // Plain column name — pull the value from the current record.
+                    $updateData[$col] = $record[$col];
+                } else {
+                    // key => literal-value override supplied by the caller.
+                    $updateData[$key] = $col;
+                }
+            }
+
+            // Attempt to UPDATE any row(s) that match the unique key columns.
+            $updateBuilder = $this->newQuery()->from($this->from);
+            foreach ($uniqueBy as $col) {
+                $updateBuilder->where($col, $record[$col]);
+            }
+
+            $rowsUpdated = $updateBuilder->update($updateData);
+
+            if ($rowsUpdated > 0) {
+                $affected += $rowsUpdated;
+            } else {
+                // Nothing matched — INSERT the full record.
+                $this->newQuery()->from($this->from)->insert($record);
+                $affected++;
+            }
+        }
+
+        return $affected;
     }
 }

--- a/src/DB2QueryBuilder.php
+++ b/src/DB2QueryBuilder.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace BWICompanies\DB2Driver;
+
+use Illuminate\Database\Query\Builder;
+
+class DB2QueryBuilder extends Builder
+{
+    /**
+     * Insert new records or update the existing ones using a DB2 MERGE statement.
+     *
+     * DB2 for i refuses to prepare any MERGE...USING (...) statement that contains
+     * parameter markers (?) inside the USING subquery — regardless of whether they
+     * are bare or wrapped in CAST(...) — raising SQL0584 or SQL0418 at SQLPrepare
+     * time.  The only viable workaround is to inline all values directly into the
+     * SQL string as properly-escaped literals, then execute with no bindings.
+     *
+     * @param  array  $values
+     * @param  array|string  $uniqueBy
+     * @param  array|null  $update
+     * @return int
+     */
+    public function upsert(array $values, $uniqueBy, $update = null): int
+    {
+        if (empty($values)) {
+            return 0;
+        }
+
+        if (! is_array(reset($values))) {
+            $values = [$values];
+        } else {
+            foreach ($values as $key => $value) {
+                ksort($value);
+                $values[$key] = $value;
+            }
+        }
+
+        if (is_null($update)) {
+            $update = array_keys(reset($values));
+        }
+
+        $this->applyBeforeQueryCallbacks();
+
+        $sql = $this->grammar->compileUpsert(
+            $this,
+            $values,
+            array_values((array) $uniqueBy),
+            is_array($update) ? $update : [$update]
+        );
+
+        // All values are inlined into $sql — pass no bindings to PDO.
+        return $this->connection->affectingStatement($sql, []);
+    }
+}

--- a/src/DB2QueryGrammar.php
+++ b/src/DB2QueryGrammar.php
@@ -250,12 +250,18 @@ class DB2QueryGrammar extends Grammar
     {
         $table = $this->wrapTable($query->from);
         $columns = array_keys(reset($values));
-        $wrappedColumns = $this->columnize($columns);
         $sourceAlias = 'laravel_source';
 
-        $parameters = collect($values)->map(function ($record) {
-            return '('.$this->parameterize($record).')';
-        })->implode(', ');
+        // DB2 for i (SQL0584) does not allow parameter markers in MERGE...USING (VALUES (?)).
+        // Work around this by building the source as SELECT ? AS col FROM SYSIBM.SYSDUMMY1,
+        // using UNION ALL for multiple rows — parameter markers are permitted in SELECT lists.
+        $source = collect($values)->map(function ($record) use ($columns) {
+            $selects = collect($columns)->map(function ($col) use ($record) {
+                return $this->parameter($record[$col]).' AS '.$this->wrap($col);
+            })->implode(', ');
+
+            return "SELECT {$selects} FROM SYSIBM.SYSDUMMY1";
+        })->implode(' UNION ALL ');
 
         $on = collect($uniqueBy)->map(function ($column) use ($table, $sourceAlias) {
             $wrapped = $this->wrap($column);
@@ -263,7 +269,7 @@ class DB2QueryGrammar extends Grammar
             return "{$table}.{$wrapped} = {$sourceAlias}.{$wrapped}";
         })->implode(' AND ');
 
-        $sql = "MERGE INTO {$table} USING (VALUES {$parameters}) AS {$sourceAlias} ({$wrappedColumns}) ON {$on}";
+        $sql = "MERGE INTO {$table} USING ({$source}) AS {$sourceAlias} ON {$on}";
 
         if (! empty($update)) {
             $sets = collect($update)->map(function ($value, $key) use ($table, $sourceAlias) {
@@ -279,11 +285,13 @@ class DB2QueryGrammar extends Grammar
             $sql .= " WHEN MATCHED THEN UPDATE SET {$sets}";
         }
 
+        $insertColumns = $this->columnize($columns);
+
         $insertValues = collect($columns)->map(function ($col) use ($sourceAlias) {
             return "{$sourceAlias}.{$this->wrap($col)}";
         })->implode(', ');
 
-        $sql .= " WHEN NOT MATCHED THEN INSERT ({$wrappedColumns}) VALUES ({$insertValues})";
+        $sql .= " WHEN NOT MATCHED THEN INSERT ({$insertColumns}) VALUES ({$insertValues})";
 
         return $sql;
     }

--- a/src/DB2QueryGrammar.php
+++ b/src/DB2QueryGrammar.php
@@ -246,18 +246,26 @@ class DB2QueryGrammar extends Grammar
      * @param  array  $update
      * @return string
      */
+    /**
+     * Compile an upsert statement into SQL using DB2's MERGE syntax.
+     *
+     * DB2 for i does not permit parameter markers (?) anywhere inside the USING
+     * subquery of a MERGE statement — not even inside CAST(? AS type) — raising
+     * SQL0584 or SQL0418 at SQLPrepare time.  All values are therefore inlined
+     * as properly-escaped SQL literals so that the statement contains no markers
+     * and can be executed with an empty bindings array.
+     *
+     * @see DB2QueryBuilder::upsert() — executes the result with no bindings.
+     */
     public function compileUpsert(Builder $query, array $values, array $uniqueBy, array $update): string
     {
         $table = $this->wrapTable($query->from);
         $columns = array_keys(reset($values));
         $sourceAlias = 'laravel_source';
 
-        // DB2 for i (SQL0584) does not allow parameter markers in MERGE...USING (VALUES (?)).
-        // Work around this by building the source as SELECT ? AS col FROM SYSIBM.SYSDUMMY1,
-        // using UNION ALL for multiple rows — parameter markers are permitted in SELECT lists.
         $source = collect($values)->map(function ($record) use ($columns) {
             $selects = collect($columns)->map(function ($col) use ($record) {
-                return $this->parameter($record[$col]).' AS '.$this->wrap($col);
+                return $this->quoteInlineValue($record[$col]).' AS '.$this->wrap($col);
             })->implode(', ');
 
             return "SELECT {$selects} FROM SYSIBM.SYSDUMMY1";
@@ -279,7 +287,8 @@ class DB2QueryGrammar extends Grammar
                     return "{$table}.{$wrapped} = {$sourceAlias}.{$wrapped}";
                 }
 
-                return $table.'.'.$this->wrap($key).' = '.$this->parameter($value);
+                // Literal override value — inline it too so there are no markers.
+                return $table.'.'.$this->wrap($key).' = '.$this->quoteInlineValue($value);
             })->implode(', ');
 
             $sql .= " WHEN MATCHED THEN UPDATE SET {$sets}";
@@ -294,6 +303,41 @@ class DB2QueryGrammar extends Grammar
         $sql .= " WHEN NOT MATCHED THEN INSERT ({$insertColumns}) VALUES ({$insertValues})";
 
         return $sql;
+    }
+
+    /**
+     * Render a PHP value as an inline SQL literal safe for embedding in a
+     * MERGE...USING subquery on DB2 for i.
+     *
+     * Single-quote escaping (doubling interior apostrophes) is the standard
+     * SQL mechanism and is fully supported by DB2 for i.  Raw Expression
+     * instances are passed through unchanged so callers can still inject
+     * hand-crafted SQL fragments when needed.
+     */
+    protected function quoteInlineValue(mixed $value): string
+    {
+        if ($this->isExpression($value)) {
+            return $this->getValue($value);
+        }
+
+        if (is_null($value)) {
+            return 'NULL';
+        }
+
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        if (is_int($value)) {
+            return (string) $value;
+        }
+
+        if (is_float($value)) {
+            return (string) $value;
+        }
+
+        // String: escape any embedded single quotes by doubling them, then wrap.
+        return "'".str_replace("'", "''", (string) $value)."'";
     }
 
     /**

--- a/src/DB2QueryGrammar.php
+++ b/src/DB2QueryGrammar.php
@@ -238,6 +238,57 @@ class DB2QueryGrammar extends Grammar
     }
 
     /**
+     * Compile an upsert statement into SQL using DB2's MERGE syntax.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @param  array  $uniqueBy
+     * @param  array  $update
+     * @return string
+     */
+    public function compileUpsert(Builder $query, array $values, array $uniqueBy, array $update): string
+    {
+        $table = $this->wrapTable($query->from);
+        $columns = array_keys(reset($values));
+        $wrappedColumns = $this->columnize($columns);
+        $sourceAlias = 'laravel_source';
+
+        $parameters = collect($values)->map(function ($record) {
+            return '('.$this->parameterize($record).')';
+        })->implode(', ');
+
+        $on = collect($uniqueBy)->map(function ($column) use ($table, $sourceAlias) {
+            $wrapped = $this->wrap($column);
+
+            return "{$table}.{$wrapped} = {$sourceAlias}.{$wrapped}";
+        })->implode(' AND ');
+
+        $sql = "MERGE INTO {$table} USING (VALUES {$parameters}) AS {$sourceAlias} ({$wrappedColumns}) ON {$on}";
+
+        if (! empty($update)) {
+            $sets = collect($update)->map(function ($value, $key) use ($table, $sourceAlias) {
+                if (is_numeric($key)) {
+                    $wrapped = $this->wrap($value);
+
+                    return "{$table}.{$wrapped} = {$sourceAlias}.{$wrapped}";
+                }
+
+                return $table.'.'.$this->wrap($key).' = '.$this->parameter($value);
+            })->implode(', ');
+
+            $sql .= " WHEN MATCHED THEN UPDATE SET {$sets}";
+        }
+
+        $insertValues = collect($columns)->map(function ($col) use ($sourceAlias) {
+            return "{$sourceAlias}.{$this->wrap($col)}";
+        })->implode(', ');
+
+        $sql .= " WHEN NOT MATCHED THEN INSERT ({$wrappedColumns}) VALUES ({$insertValues})";
+
+        return $sql;
+    }
+
+    /**
      * Compile the SQL statement to define a savepoint.
      *
      * @param  string  $name

--- a/src/Schema/DB2Blueprint.php
+++ b/src/Schema/DB2Blueprint.php
@@ -43,13 +43,20 @@ class DB2Blueprint extends Blueprint
      * @param  \Illuminate\Database\Schema\Grammars\Grammar  $grammar
      * @return array
      */
-    public function toSql(Connection $connection, Grammar $grammar)
+    //DWMOD - the function signature of toSql has changed in laravel 12, it no longer accepts the connection and grammar as parameters, so we need to update the function signature and use the class properties instead of the passed arguments
+    // public function toSql(Connection $connection, Grammar $grammar)
+    // {
+    //     $this->addReplyListEntryCommands($connection);
+
+    //     return parent::toSql($connection, $grammar);
+    // }
+    public function toSql()
     {
-        $this->addReplyListEntryCommands($connection);
+        // Use the class properties instead of passed arguments
+        $this->addReplyListEntryCommands($this->connection);
 
-        return parent::toSql($connection, $grammar);
+        return parent::toSql();
     }
-
     /**
      * Add the commands that are necessary to DROP and Rename statements on IBMi.
      *
@@ -93,7 +100,9 @@ class DB2Blueprint extends Blueprint
      * @param  string  $index
      * @return \Illuminate\Support\Fluent
      */
-    protected function indexCommand($type, $columns, $index, $algorithm = null)
+    //DWMOD - the indexCommand method in the parent class has been updated to accept an operatorClass parameter, so we need to update the function signature to match it
+    //protected function indexCommand($type, $columns, $index, $algorithm = null)
+    protected function indexCommand($type, $columns, $index, $algorithm = null, $operatorClass = null)
     {
         $columns = (array) $columns;
 

--- a/src/Schema/DB2Builder.php
+++ b/src/Schema/DB2Builder.php
@@ -112,6 +112,48 @@ class DB2Builder extends Builder
 
 
     /**
+     * Drop all tables from the current schema.
+     *
+     * Referential constraints (foreign keys) are removed first so that FK
+     * dependencies do not block the subsequent DROP TABLE statements.
+     */
+    public function dropAllTables(): void
+    {
+        $schema = strtoupper($this->connection->getDefaultSchema());
+
+        $tables = $this->connection->select(
+            "select table_name from information_schema.tables
+              where table_schema = ? and table_type = 'BASE TABLE'",
+            [$schema]
+        );
+
+        if (empty($tables)) {
+            return;
+        }
+
+        // Drop all foreign-key constraints before dropping tables so that
+        // referential integrity does not prevent the DROP TABLE statements.
+        foreach ($tables as $table) {
+            $constraints = $this->connection->select(
+                "select constraint_name from information_schema.table_constraints
+                  where table_schema = ? and table_name = ? and constraint_type = 'FOREIGN KEY'",
+                [$schema, strtoupper($table->table_name)]
+            );
+
+            foreach ($constraints as $constraint) {
+                $this->connection->statement(
+                    "ALTER TABLE {$schema}.{$table->table_name}
+                     DROP FOREIGN KEY {$constraint->constraint_name}"
+                );
+            }
+        }
+
+        foreach ($tables as $table) {
+            $this->connection->statement("DROP TABLE {$schema}.{$table->table_name}");
+        }
+    }
+
+    /**
      * Execute the blueprint to build / modify the table.
      */
     protected function build(Blueprint $blueprint)

--- a/src/Schema/DB2Builder.php
+++ b/src/Schema/DB2Builder.php
@@ -13,8 +13,11 @@ class DB2Builder extends Builder
      */
     public function hasTable($table): bool
     {
-        $sql = $this->grammar->compileTableExists();
+        //DWMOD - the compileTableExists method in DB2SchemaGrammar has been updated to accept the schema as a parameter, so we need to pass the schema when calling it
+        //$sql = $this->grammar->compileTableExists();
+        $sql = $this->grammar->compileTableExists($this->connection->getConfig('schema'), $table);
         $schemaTable = explode('.', $table);
+
 
         if (count($schemaTable) > 1) {
             $schema = $schemaTable[0];
@@ -24,21 +27,72 @@ class DB2Builder extends Builder
             $table = $this->connection->getTablePrefix().$table;
         }
 
+
+        //DWMOD - we need to pass the schema as a parameter to the query, and we can get it from the connection config or from the table name if it is specified in the table name
+        //return count($this->connection->select($sql, [
+        //    $schema,
+        //    $table,
+        //])) > 0;
         return count($this->connection->select($sql, [
-            $schema,
-            $table,
+            $this->connection->getConfig('schema'),
+            $table
+        ])) > 0;
+    }
+
+    //DWMOD - add a hasCol
+    public function hasColumn($table, $column)
+    {
+        $schema = $this->connection->getConfig('schema');
+        
+        // Pass all 3 required arguments to the grammar
+        $sql = $this->grammar->compileColumnExists($schema, $table, $column);
+
+        return count($this->connection->select($sql, [
+            strtoupper($schema), 
+            strtoupper($table), 
+            strtoupper($column)
         ])) > 0;
     }
 
     /**
      * Get the column listing for a given table.
      */
+    //DWMOD - the getColumnListing method in the parent class has been updated to accept the connection and grammar as parameters, so we need to update the function signature to match it and use the passed arguments instead of the class properties
+    // public function getColumnListing($table): array
+    // {
+    //     $sql = $this->grammar->compileColumnExists();
+    //     $database = $this->connection->getDatabaseName();
+    //     $table = $this->connection->getTablePrefix().$table;
+
+    //     $tableExploded = explode('.', $table);
+
+    //     if (count($tableExploded) > 1) {
+    //         $database = $tableExploded[0];
+    //         $table = $tableExploded[1];
+    //     }
+
+    //     $results = $this->connection->select($sql, [
+    //         $database,
+    //         $table,
+    //     ]);
+
+    //     $res = $this->connection->getPostProcessor()
+    //                             ->processColumnListing($results);
+
+    //     return array_values(array_map(function ($r) {
+    //         return $r->column_name;
+    //     }, $res));
+    // }
     public function getColumnListing($table): array
     {
-        $sql = $this->grammar->compileColumnExists();
+        $schema = $this->connection->getConfig('schema');
+        
+        // 1. Use the correct grammar method for a LISTING, not an EXISTS check
+        $sql = $this->grammar->compileColumnListing($schema, $table);
+
+        // 2. Handle potential table prefixes or exploded names
         $database = $this->connection->getDatabaseName();
         $table = $this->connection->getTablePrefix().$table;
-
         $tableExploded = explode('.', $table);
 
         if (count($tableExploded) > 1) {
@@ -46,18 +100,16 @@ class DB2Builder extends Builder
             $table = $tableExploded[1];
         }
 
+        // 3. Bind only the Schema and Table (Upper-cased for DB2)
         $results = $this->connection->select($sql, [
-            $database,
-            $table,
+            strtoupper($database),
+            strtoupper($table)
         ]);
 
-        $res = $this->connection->getPostProcessor()
-                                ->processColumnListing($results);
-
-        return array_values(array_map(function ($r) {
-            return $r->column_name;
-        }, $res));
+        // 4. Let the PostProcessor handle the mapping to column names
+        return $this->connection->getPostProcessor()->processColumnListing($results);
     }
+
 
     /**
      * Execute the blueprint to build / modify the table.
@@ -77,12 +129,18 @@ class DB2Builder extends Builder
     /**
      * Create a new command set with a Closure.
      */
+    //DWMOD - the createBlueprint method in the parent class has been updated to accept the connection as a parameter, so we need to pass the connection when creating a new blueprint instance
+    // protected function createBlueprint($table, Closure $callback = null)
+    // {
+    //     if (isset($this->resolver)) {
+    //         return call_user_func($this->resolver, $table, $callback);
+    //     }
+
+    //     return new DB2Blueprint($table, $callback);
+    // }
     protected function createBlueprint($table, Closure $callback = null)
     {
-        if (isset($this->resolver)) {
-            return call_user_func($this->resolver, $table, $callback);
-        }
-
-        return new DB2Blueprint($table, $callback);
+        // Pass $this->connection as the first argument
+        return new DB2Blueprint($this->connection, $table, $callback);
     }
 }

--- a/src/Schema/DB2SchemaGrammar.php
+++ b/src/Schema/DB2SchemaGrammar.php
@@ -466,13 +466,6 @@ class DB2SchemaGrammar extends Grammar
      */
     protected function typeText(Fluent $column)
     {
-        // CLOB is a character type and cannot carry CCSID 65535 (binary).
-        // When binary storage is configured, use BLOB instead — it is the
-        // binary-safe equivalent and does not require a character CCSID.
-        if ((int) $this->connection?->getConfig('column_ccsid') === 65535) {
-            return 'blob';
-        }
-
         return "clob(64K){$this->columnCcsid()}";
     }
 
@@ -484,9 +477,12 @@ class DB2SchemaGrammar extends Grammar
      */
     protected function typeMediumText(Fluent $column)
     {
-        $colLength = ($column->length ? $column->length : 16000);
-
-        return "varchar($colLength){$this->columnCcsid()}";
+        // PHP's serialize() embeds null bytes (\x00*\x00name) for protected
+        // property visibility markers. EBCDIC character columns reject null
+        // bytes during ODBC code-page conversion (CWBNL0107 / SQLSTATE 22018).
+        // BLOB stores raw bytes without any CCSID conversion, making it safe
+        // for cache values, session payloads, and any other serialised data.
+        return 'blob';
     }
 
     /**

--- a/src/Schema/DB2SchemaGrammar.php
+++ b/src/Schema/DB2SchemaGrammar.php
@@ -477,12 +477,9 @@ class DB2SchemaGrammar extends Grammar
      */
     protected function typeMediumText(Fluent $column)
     {
-        // PHP's serialize() embeds null bytes (\x00*\x00name) for protected
-        // property visibility markers. EBCDIC character columns reject null
-        // bytes during ODBC code-page conversion (CWBNL0107 / SQLSTATE 22018).
-        // BLOB stores raw bytes without any CCSID conversion, making it safe
-        // for cache values, session payloads, and any other serialised data.
-        return 'blob';
+        $colLength = ($column->length ? $column->length : 16000);
+
+        return "varchar($colLength){$this->columnCcsid()}";
     }
 
     /**

--- a/src/Schema/DB2SchemaGrammar.php
+++ b/src/Schema/DB2SchemaGrammar.php
@@ -444,7 +444,7 @@ class DB2SchemaGrammar extends Grammar
      */
     protected function typeChar(Fluent $column)
     {
-        return "char({$column->length})";
+        return "char({$column->length}){$this->columnCcsid()}";
     }
 
     /**
@@ -455,7 +455,7 @@ class DB2SchemaGrammar extends Grammar
      */
     protected function typeString(Fluent $column)
     {
-        return "varchar({$column->length})";
+        return "varchar({$column->length}){$this->columnCcsid()}";
     }
 
     /**
@@ -466,7 +466,7 @@ class DB2SchemaGrammar extends Grammar
      */
     protected function typeText(Fluent $column)
     {
-        return 'clob(64K)';
+        return "clob(64K){$this->columnCcsid()}";
     }
 
     /**
@@ -479,7 +479,7 @@ class DB2SchemaGrammar extends Grammar
     {
         $colLength = ($column->length ? $column->length : 16000);
 
-        return "varchar($colLength)";
+        return "varchar($colLength){$this->columnCcsid()}";
     }
 
     /**
@@ -492,7 +492,28 @@ class DB2SchemaGrammar extends Grammar
     {
         $colLength = ($column->length ? $column->length : 16000);
 
-        return "varchar($colLength)";
+        return "varchar($colLength){$this->columnCcsid()}";
+    }
+
+    /**
+     * Return a CCSID clause for character column definitions, e.g. " CCSID 819".
+     *
+     * When the connection config contains a 'column_ccsid' value the clause is
+     * appended to every CHAR, VARCHAR, and CLOB column so that new tables are
+     * created with the correct character set.  Setting this to 819 (ISO-8859-1)
+     * and also adding CCSID=819 to the ODBC connection keywords means that the
+     * source and target CCSIDs always match, the IBM i ODBC driver skips
+     * code-page conversion entirely, and null bytes in PHP-serialised data are
+     * stored and retrieved without error (CWBNL0107 / SQLSTATE 22018).
+     *
+     * When 'column_ccsid' is absent the method returns an empty string, leaving
+     * existing behaviour unchanged.
+     */
+    private function columnCcsid(): string
+    {
+        $ccsid = $this->connection?->getConfig('column_ccsid');
+
+        return $ccsid !== null ? " CCSID {$ccsid}" : '';
     }
 
     /**

--- a/src/Schema/DB2SchemaGrammar.php
+++ b/src/Schema/DB2SchemaGrammar.php
@@ -58,7 +58,9 @@ class DB2SchemaGrammar extends Grammar
      *
      * @return string
      */
-    public function compileTableExists()
+    //DWMOD - function signature has changed in laravel 12
+    //public function compileTableExists()
+    public function compileTableExists($schema, $table)
     {
         return 'select * from information_schema.tables where table_schema = upper(?) and table_name = upper(?)';
     }
@@ -68,7 +70,22 @@ class DB2SchemaGrammar extends Grammar
      *
      * @return string
      */
-    public function compileColumnExists()
+    //DWMOD - function signature has changed in laravel 12
+    //public function compileColumnExists()
+    public function compileColumnExists($schema, $table, $column)
+    {
+        return 'select column_name from information_schema.columns where table_schema = upper(?) and table_name = upper(?) and column_name = upper(?)';
+    }
+
+    //DWMOD - add a compileColumnListing method to get the list of columns for a table, since DB2 does not support the standard information_schema.columns query that Laravel uses by default, and we need to provide our own implementation to get the column listing for a given table
+    /**
+     * Compile the query to determine the list of columns.
+     *
+     * @param  string  $schema
+     * @param  string  $table
+     * @return string
+     */
+    public function compileColumnListing($schema, $table)
     {
         return 'select column_name from information_schema.columns where table_schema = upper(?) and table_name = upper(?)';
     }
@@ -78,10 +95,11 @@ class DB2SchemaGrammar extends Grammar
      *
      * @param  \Illuminate\Database\Schema\Blueprint  $blueprint
      * @param  \Illuminate\Support\Fluent  $command
-     * @param  \Illuminate\Database\Connection  $connection
      * @return string
      */
-    public function compileCreate(Blueprint $blueprint, Fluent $command, Connection $connection)
+    //DWMOD - the function signature of compileCreate has changed in laravel 12, it no longer accepts the connection as a parameter, so we need to update the function signature and use the class property instead of the passed argument
+    //public function compileCreate(Blueprint $blueprint, Fluent $command, Connection $connection)
+    public function compileCreate(Blueprint $blueprint, Fluent $command)
     {
         $columns = implode(', ', $this->getColumns($blueprint));
         $sql = 'create table '.$this->wrapTable($blueprint);
@@ -103,7 +121,9 @@ class DB2SchemaGrammar extends Grammar
      * @param  \Illuminate\Database\Connection  $connection
      * @return string
      */
-    public function compileLabel(Blueprint $blueprint, Fluent $command, Connection $connection)
+    //DWMOD - the function signature of compileLabel has changed in laravel 12, it no longer accepts the connection as a parameter, so we need to update the function signature and use the class property instead of the passed argument
+    //public function compileLabel(Blueprint $blueprint, Fluent $command, Connection $connection)
+    public function compileLabel(Blueprint $blueprint, Fluent $command)
     {
         return 'label on table '.$this->wrapTable($blueprint).' is \''.$command->label.'\'';
     }
@@ -819,29 +839,38 @@ class DB2SchemaGrammar extends Grammar
      * @param  \Illuminate\Database\Connection  $connection
      * @return string
      */
-    public function compileAddReplyListEntry(Blueprint $blueprint, Fluent $command, Connection $connection)
+    //DWMOD - the function signature of compileAddReplyListEntry has changed in laravel 12, it no longer accepts the connection as a parameter, so we need to update the function signature and use the class property instead of the passed argument
+    //public function compileAddReplyListEntry(Blueprint $blueprint, Fluent $command, Connection $connection)
+    public function compileAddReplyListEntry(Blueprint $blueprint, Fluent $command)
     {
-        $sequenceNumberQuery = <<<'EOT'
-            with reply_list_info(sequence_number) as (
-                values(1)
-                union all
-                select sequence_number + 1
-                from reply_list_info
-                where sequence_number + 1 between 2 and 9999
-            )
-            select min(sequence_number) sequence_number
-            from reply_list_info
-            where not exists (
-                select 1
-                from qsys2.reply_list_info rli
-                where rli.sequence_number = reply_list_info.sequence_number
-            )
-EOT;
+//DWMOD - get connection from blueprint instead of from the passed argument, as the function signature has changed in laravel 12 and it no longer accepts the connection as a parameter
+//         $connection = $this->connection;
 
-        $blueprint->setReplyListSequenceNumber($sequenceNumber = $connection->selectOne($sequenceNumberQuery)->sequence_number);
-        $command->command = "ADDRPYLE SEQNBR($sequenceNumber) MSGID(CPA32B2) RPY(''I'')";
+//         $sequenceNumberQuery = <<<'EOT'
+//             with reply_list_info(sequence_number) as (
+//                 values(1)
+//                 union all
+//                 select sequence_number + 1
+//                 from reply_list_info
+//                 where sequence_number + 1 between 2 and 9999
+//             )
+//             select min(sequence_number) sequence_number
+//             from reply_list_info
+//             where not exists (
+//                 select 1
+//                 from qsys2.reply_list_info rli
+//                 where rli.sequence_number = reply_list_info.sequence_number
+//             )
+// EOT;
 
-        return $this->compileExecuteCommand($blueprint, $command);
+//         $blueprint->setReplyListSequenceNumber($sequenceNumber = $connection->selectOne($sequenceNumberQuery)->sequence_number);
+//         $command->command = "ADDRPYLE SEQNBR($sequenceNumber) MSGID(CPA32B2) RPY(''I'')";
+
+//         return $this->compileExecuteCommand($blueprint, $command);
+
+        //DWMOD We are neutralizing this to avoid authority/system-wide collision errors.
+        // This just returns a dummy SQL statement that does nothing.
+        return 'SELECT 1 FROM SYSIBM.SYSDUMMY1';
     }
 
     /**
@@ -853,10 +882,12 @@ EOT;
      */
     public function compileRemoveReplyListEntry(Blueprint $blueprint, Fluent $command)
     {
-        $sequenceNumber = $blueprint->getReplyListSequenceNumber();
-        $command->command = "RMVRPYLE SEQNBR($sequenceNumber)";
+        //DWMOD - bypass the system command execution.
+        // $sequenceNumber = $blueprint->getReplyListSequenceNumber();
+        // $command->command = "RMVRPYLE SEQNBR($sequenceNumber)";
 
-        return $this->compileExecuteCommand($blueprint, $command);
+        // return $this->compileExecuteCommand($blueprint, $command);
+        return 'SELECT 1 FROM SYSIBM.SYSDUMMY1';
     }
 
     /**
@@ -871,5 +902,28 @@ EOT;
         $command->command = 'CHGJOB INQMSGRPY(*SYSRPYL)';
 
         return $this->compileExecuteCommand($blueprint, $command);
+    }
+
+    //DWMOD - add type definitions for tinyInteger and mediumInteger, as they are not supported by DB2 but are supported by Laravel, so we need to map them to smallint and integer respectively
+    /**
+     * Create the column definition for a tiny integer type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeTinyInteger(\Illuminate\Support\Fluent $column)
+    {
+        return 'smallint';
+    }
+
+    /**
+     * Create the column definition for a medium integer type.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeMediumInteger(\Illuminate\Support\Fluent $column)
+    {
+        return 'integer';
     }
 }

--- a/src/Schema/DB2SchemaGrammar.php
+++ b/src/Schema/DB2SchemaGrammar.php
@@ -466,6 +466,13 @@ class DB2SchemaGrammar extends Grammar
      */
     protected function typeText(Fluent $column)
     {
+        // CLOB is a character type and cannot carry CCSID 65535 (binary).
+        // When binary storage is configured, use BLOB instead — it is the
+        // binary-safe equivalent and does not require a character CCSID.
+        if ((int) $this->connection?->getConfig('column_ccsid') === 65535) {
+            return 'blob';
+        }
+
         return "clob(64K){$this->columnCcsid()}";
     }
 


### PR DESCRIPTION
Note: Most of these changes were suggested by Gemini, I was mainly just copying and pasting.

This PR provides necessary updates to support Laravel 11 and 12. Recent framework changes modified several internal Schema signatures and property visibilities which previously caused FatalErrors and BadMethodCallExceptions.

Key Changes:
Framework Compatibility:

Updated DB2Blueprint::indexCommand to include the $operatorClass parameter.

Updated DB2SchemaGrammar compile methods (compileCreate, compileAdd, etc.) to match the new 2-argument signature.

Adjusted DB2Builder::createBlueprint to pass the Connection object as the first argument.

Data Type Support:

Added typeTinyInteger and typeMediumInteger mappings to the Grammar to prevent crashes during standard Laravel migrations (e.g., the jobs table).

IBM i Specific Fixes:

Added PDO::ATTR_CASE => PDO::CASE_LOWER to DB2Connection to resolve case-sensitivity issues with migration metadata.

Neutralized compileAddReplyListEntry/compileDropReplyListEntry to prevent SQL0551 (Authority) and CPF0006 (Sequence collision) errors on locked systems.

Fixed hasColumn and getColumnListing to properly utilize INFORMATION_SCHEMA with upper-cased library/table bindings.